### PR TITLE
Improvements to Hadoop datasource reader

### DIFF
--- a/components/data-sources/org.wso2.carbon.datasource.reader.hadoop/src/main/java/org/wso2/carbon/datasource/reader/hadoop/HBaseDataSourceReader.java
+++ b/components/data-sources/org.wso2.carbon.datasource.reader.hadoop/src/main/java/org/wso2/carbon/datasource/reader/hadoop/HBaseDataSourceReader.java
@@ -17,10 +17,15 @@
 */
 package org.wso2.carbon.datasource.reader.hadoop;
 
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.client.Connection;
+import org.apache.hadoop.hbase.client.ConnectionFactory;
 import org.wso2.carbon.ndatasource.common.DataSourceException;
 import org.wso2.carbon.ndatasource.common.spi.DataSourceReader;
 
-/***
+import java.io.IOException;
+
+/**
  * HBase implementation of {@link org.wso2.carbon.ndatasource.common.spi.DataSourceReader}
  */
 public class HBaseDataSourceReader implements DataSourceReader {
@@ -32,12 +37,17 @@ public class HBaseDataSourceReader implements DataSourceReader {
 
     @Override
     public Object createDataSource(String xmlConfig, boolean isDataSourceFactoryReference) throws DataSourceException {
-        return HadoopDataSourceReaderUtil.getHBaseConnection(xmlConfig);
+        return HadoopDataSourceReaderUtil.loadConfig(xmlConfig);
     }
 
     @Override
     public boolean testDataSourceConnection(String xmlConfig) throws DataSourceException {
-        return true;
+        Configuration config = (Configuration) createDataSource(xmlConfig, true);
+        try (Connection conn = ConnectionFactory.createConnection(config)) {
+            return (conn == null);
+        } catch (IOException e) {
+            throw new DataSourceException("Cannot establish connection to HBase instance for testing: " + e.getMessage(), e);
+        }
     }
 
 }

--- a/components/data-sources/org.wso2.carbon.datasource.reader.hadoop/src/main/java/org/wso2/carbon/datasource/reader/hadoop/HDFSDataSourceReader.java
+++ b/components/data-sources/org.wso2.carbon.datasource.reader.hadoop/src/main/java/org/wso2/carbon/datasource/reader/hadoop/HDFSDataSourceReader.java
@@ -17,10 +17,14 @@
 */
 package org.wso2.carbon.datasource.reader.hadoop;
 
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
 import org.wso2.carbon.ndatasource.common.DataSourceException;
 import org.wso2.carbon.ndatasource.common.spi.DataSourceReader;
 
-/***
+import java.io.IOException;
+
+/**
  * HDFS implementation of {@link org.wso2.carbon.ndatasource.common.spi.DataSourceReader}
  */
 public class HDFSDataSourceReader implements DataSourceReader {
@@ -32,12 +36,17 @@ public class HDFSDataSourceReader implements DataSourceReader {
 
     @Override
     public Object createDataSource(String xmlConfig, boolean isDataSourceFactoryReference) throws DataSourceException {
-        return HadoopDataSourceReaderUtil.getHadoopFileSystem(xmlConfig);
+        return HadoopDataSourceReaderUtil.loadConfig(xmlConfig);
     }
 
     @Override
     public boolean testDataSourceConnection(String xmlConfig) throws DataSourceException {
-        return true;
+        Configuration config = (Configuration) createDataSource(xmlConfig, true);
+        try (FileSystem fileSystem = FileSystem.get(config)) {
+            return (fileSystem == null);
+        } catch (IOException e) {
+            throw new DataSourceException("Cannot establish connection to HDFS instance for testing: " + e.getMessage(), e);
+        }
     }
 
 }

--- a/components/data-sources/org.wso2.carbon.datasource.reader.hadoop/src/main/java/org/wso2/carbon/datasource/reader/hadoop/HadoopDataSourceReaderUtil.java
+++ b/components/data-sources/org.wso2.carbon.datasource.reader.hadoop/src/main/java/org/wso2/carbon/datasource/reader/hadoop/HadoopDataSourceReaderUtil.java
@@ -18,9 +18,6 @@
 package org.wso2.carbon.datasource.reader.hadoop;
 
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.FileSystem;
-import org.apache.hadoop.hbase.client.Connection;
-import org.apache.hadoop.hbase.client.ConnectionFactory;
 import org.wso2.carbon.ndatasource.common.DataSourceException;
 import org.wso2.carbon.utils.CarbonUtils;
 
@@ -58,30 +55,6 @@ public class HadoopDataSourceReaderUtil {
                 }
             }
         }
-    }
-
-    public static FileSystem getHadoopFileSystem(String xmlConfig) throws DataSourceException {
-        Configuration configuration = HadoopDataSourceReaderUtil.loadConfig(xmlConfig);
-        FileSystem fileSystem;
-        try {
-            fileSystem = FileSystem.get(configuration);
-        } catch (IOException e) {
-            throw new DataSourceException("Cannot initialize Hadoop FileSystem from configuration:" + e.getMessage(), e);
-        }
-        return fileSystem;
-    }
-
-
-    public static Connection getHBaseConnection(String xmlConfig) throws DataSourceException {
-        Configuration configuration = HadoopDataSourceReaderUtil.loadConfig(xmlConfig);
-        Connection connection;
-        try {
-            connection = ConnectionFactory.createConnection(configuration);
-
-        } catch (IOException e) {
-            throw new DataSourceException("Cannot create Hadoop Connection from configuration:" + e.getMessage(), e);
-        }
-        return connection;
     }
 
 }


### PR DESCRIPTION
- Return a generic Configuration instance instead of actual connection transients
- Implement testDataSourceConnection() for HDFS and HBase