### PR TITLE
Remove transaction isolation assignment.

### DIFF
--- a/components/data-services/org.wso2.carbon.dataservices.core/src/main/java/org/wso2/carbon/dataservices/core/odata/RDBMSDataHandler.java
+++ b/components/data-services/org.wso2.carbon.dataservices.core/src/main/java/org/wso2/carbon/dataservices/core/odata/RDBMSDataHandler.java
@@ -126,7 +126,6 @@ public class RDBMSDataHandler implements ODataDataHandler {
                 this.defaultAutoCommit = connection.getAutoCommit();
                 connection.setAutoCommit(false);
                 this.defaultTransactionalIsolation = connection.getTransactionIsolation();
-                connection.setTransactionIsolation(Connection.TRANSACTION_REPEATABLE_READ);
                 transactionalConnection.set(connection);
             }
         } catch (SQLException e) {


### PR DESCRIPTION
Use case: I have an Oracle datasource in the DSS and a service using that datasource with OData enabled.

Bug: When I make a batch request with data modifications (within a change set) the server fails.

Solution: Remove the transaction isolation assignment, so it can use the datasource configuration. I debugged this code with the datasource's parameter "Default Transaction Isolation" set to "NONE", and the DSS take READ_COMMITED by default (it works).

Trace: [2016-07-11 12:52:40,158] ERROR -  Error occurred while starting the transaction. :DS Fault Message: OData Service Fault : Connection Error occurred. :READ_COMMITTED and SERIALIZABLE are the only valid transaction levels_DS Code: UNKNOWN_ERROR_Nested Exception:-_java.sql.SQLException: READ_COMMITTED and SERIALIZABLE are the only valid transaction levels_ (Sanitized) {org.wso2.carbon.dataservices.core.odata.ODataAdapter}
DS Fault Message: OData Service Fault : Connection Error occurred. :READ_COMMITTED and SERIALIZABLE are the only valid transaction levels
DS Code: UNKNOWN_ERROR
Nested Exception:-
java.sql.SQLException: READ_COMMITTED and SERIALIZABLE are the only valid transaction levels

	at org.wso2.carbon.dataservices.core.odata.RDBMSDataHandler.openTransaction(RDBMSDataHandler.java:133)
	at org.wso2.carbon.dataservices.core.odata.ODataAdapter.startTransaction(ODataAdapter.java:894)
	at org.apache.olingo.server.core.requests.BatchRequest.execute(BatchRequest.java:82)
	at org.apache.olingo.server.core.ServiceDispatcher.execute(ServiceDispatcher.java:117)
	at org.apache.olingo.server.core.OData4HttpHandler.process(OData4HttpHandler.java:65)
	at org.wso2.carbon.dataservices.core.odata.ODataServiceHandler.process(ODataServiceHandler.java:77)
	at org.wso2.carbon.dataservices.odata.endpoint.ODataEndpoint.process(ODataEndpoint.java:60)
	at org.wso2.carbon.dataservices.odata.ODataServlet.service(ODataServlet.java:31)
	at javax.servlet.http.HttpServlet.service(HttpServlet.java:727)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:303)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:208)
	at org.apache.tomcat.websocket.server.WsFilter.doFilter(WsFilter.java:52)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:241)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:208)
	at org.apache.catalina.core.StandardWrapperValve.invoke(StandardWrapperValve.java:220)
	at org.apache.catalina.core.StandardContextValve.invoke(StandardContextValve.java:122)
	at org.apache.catalina.authenticator.AuthenticatorBase.invoke(AuthenticatorBase.java:613)
	at org.apache.catalina.core.StandardHostValve.invoke(StandardHostValve.java:170)
	at org.apache.catalina.valves.ErrorReportValve.invoke(ErrorReportValve.java:103)
	at org.wso2.carbon.tomcat.ext.valves.CompositeValve.continueInvocation(CompositeValve.java:99)
	at org.wso2.carbon.tomcat.ext.valves.CarbonTomcatValve$1.invoke(CarbonTomcatValve.java:47)
	at org.wso2.carbon.webapp.mgt.TenantLazyLoaderValve.invoke(TenantLazyLoaderValve.java:57)
	at org.wso2.carbon.tomcat.ext.valves.TomcatValveContainer.invokeValves(TomcatValveContainer.java:47)
	at org.wso2.carbon.tomcat.ext.valves.CompositeValve.invoke(CompositeValve.java:62)
	at org.wso2.carbon.tomcat.ext.valves.CarbonStuckThreadDetectionValve.invoke(CarbonStuckThreadDetectionValve.java:159)
	at org.apache.catalina.valves.AccessLogValve.invoke(AccessLogValve.java:950)
	at org.wso2.carbon.tomcat.ext.valves.CarbonContextCreatorValve.invoke(CarbonContextCreatorValve.java:57)
	at org.apache.catalina.core.StandardEngineValve.invoke(StandardEngineValve.java:116)
	at org.apache.catalina.connector.CoyoteAdapter.service(CoyoteAdapter.java:421)
	at org.apache.coyote.http11.AbstractHttp11Processor.process(AbstractHttp11Processor.java:1074)
	at org.apache.coyote.AbstractProtocol$AbstractConnectionHandler.process(AbstractProtocol.java:611)
	at org.apache.tomcat.util.net.NioEndpoint$SocketProcessor.doRun(NioEndpoint.java:1739)
	at org.apache.tomcat.util.net.NioEndpoint$SocketProcessor.run(NioEndpoint.java:1698)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:615)
	at org.apache.tomcat.util.threads.TaskThread$WrappingRunnable.run(TaskThread.java:61)
	at java.lang.Thread.run(Thread.java:745)
Caused by: java.sql.SQLException: READ_COMMITTED and SERIALIZABLE are the only valid transaction levels
	at oracle.jdbc.driver.PhysicalConnection.setTransactionIsolation(PhysicalConnection.java:4638)
	at sun.reflect.GeneratedMethodAccessor449.invoke(Unknown Source)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:606)
	at org.apache.tomcat.jdbc.pool.ProxyConnection.invoke(ProxyConnection.java:126)
	at org.apache.tomcat.jdbc.pool.JdbcInterceptor.invoke(JdbcInterceptor.java:109)
	at org.wso2.carbon.ndatasource.rdbms.ConnectionRollbackOnReturnInterceptor.invoke(ConnectionRollbackOnReturnInterceptor.java:51)
	at org.apache.tomcat.jdbc.pool.JdbcInterceptor.invoke(JdbcInterceptor.java:109)
	at org.apache.tomcat.jdbc.pool.interceptor.AbstractCreateStatementInterceptor.invoke(AbstractCreateStatementInterceptor.java:71)
	at org.apache.tomcat.jdbc.pool.JdbcInterceptor.invoke(JdbcInterceptor.java:109)
	at org.apache.tomcat.jdbc.pool.interceptor.ConnectionState.invoke(ConnectionState.java:153)
	at org.apache.tomcat.jdbc.pool.JdbcInterceptor.invoke(JdbcInterceptor.java:109)
	at org.apache.tomcat.jdbc.pool.TrapException.invoke(TrapException.java:41)
	at org.apache.tomcat.jdbc.pool.JdbcInterceptor.invoke(JdbcInterceptor.java:109)
	at org.apache.tomcat.jdbc.pool.DisposableConnectionFacade.invoke(DisposableConnectionFacade.java:80)
	at com.sun.proxy.$Proxy13.setTransactionIsolation(Unknown Source)
	at org.wso2.carbon.dataservices.core.odata.RDBMSDataHandler.openTransaction(RDBMSDataHandler.java:129)
	... 36 more