### PR TITLE
Add sslInvalidHostnameAllowed option

### DIFF
--- a/components/data-sources/org.wso2.carbon.datasource.reader.mongo/src/main/java/org/wso2/carbon/datasource/reader/mongo/MongoDataSourceReaderUtil.java
+++ b/components/data-sources/org.wso2.carbon.datasource.reader.mongo/src/main/java/org/wso2/carbon/datasource/reader/mongo/MongoDataSourceReaderUtil.java
@@ -50,8 +50,12 @@ public class MongoDataSourceReaderUtil {
             baos = new ByteArrayInputStream(xmlConfiguration.getBytes());
             MongoDataSourceConfiguration fileConfig = (MongoDataSourceConfiguration) ctx.createUnmarshaller().unmarshal(baos);
             MongoClient result = null;
+            MongoClientOptions.Builder builder = MongoClientOptions.builder();
             if (fileConfig.getUrl() != null) {
-                MongoClientURI uri = new MongoClientURI(fileConfig.getUrl());
+                if (fileConfig.getSslInvalidHostNameAllowed() != null) {
+                    builder.sslInvalidHostNameAllowed(fileConfig.getSslInvalidHostNameAllowed());
+                }
+                MongoClientURI uri = new MongoClientURI(fileConfig.getUrl(), builder);
                 result = new MongoClient(uri);
             } else {
                 List<ServerAddress> addressList = new ArrayList<ServerAddress>();
@@ -73,10 +77,12 @@ public class MongoDataSourceReaderUtil {
                     ServerAddress address = new ServerAddress(fileConfig.getHost(), Integer.parseInt(fileConfig.getPort()));
                     addressList.add(address);
                 }
-                MongoClientOptions.Builder builder = MongoClientOptions.builder();
                 MongoCredential credential = null;
                 if (fileConfig.getWithSSL() != null) {
                     builder.sslEnabled(fileConfig.getWithSSL());
+                }
+                if (fileConfig.getSslInvalidHostNameAllowed() != null) {
+                    builder.sslInvalidHostNameAllowed(fileConfig.getSslInvalidHostNameAllowed());
                 }
                 if (fileConfig.getAuthenticationMethodEnum() != null && fileConfig.getUsername() != null) {
                     credential = createCredentials(fileConfig);

--- a/components/data-sources/org.wso2.carbon.datasource.reader.mongo/src/main/java/org/wso2/carbon/datasource/reader/mongo/config/MongoDataSourceConfiguration.java
+++ b/components/data-sources/org.wso2.carbon.datasource.reader.mongo/src/main/java/org/wso2/carbon/datasource/reader/mongo/config/MongoDataSourceConfiguration.java
@@ -52,6 +52,17 @@ public class MongoDataSourceConfiguration {
 
     private String authSource;
 
+    private Boolean sslInvalidHostNameAllowed;
+
+    @XmlElement(name = "sslInvalidHostNameAllowed")
+    public Boolean getSslInvalidHostNameAllowed() {
+        return sslInvalidHostNameAllowed;
+    }
+
+    public void setSslInvalidHostNameAllowed(Boolean sslInvalidHostNameAllowed) {
+        this.sslInvalidHostNameAllowed = sslInvalidHostNameAllowed;
+    }
+
     @XmlElement(name = "host")
     public String getHost() {
         return host;


### PR DESCRIPTION
Hi,

In our tests, this option has proved to be very handy when relaying on self-signed certificates. As it was not directly configurable with the options included, I've added the option in the configuration. Please, check it and merge if you consider it helpful.

Thanks,

Jose Maria.