### PR TITLE
Release lock when exception occured while creating connection to excel

### DIFF
--- a/components/data-services/org.wso2.carbon.dataservices.sql.driver/src/main/java/org/wso2/carbon/dataservices/sql/driver/TExcelConnection.java
+++ b/components/data-services/org.wso2.carbon.dataservices.sql.driver/src/main/java/org/wso2/carbon/dataservices/sql/driver/TExcelConnection.java
@@ -73,11 +73,14 @@ public class TExcelConnection extends TConnection {
             InputStream fin = TDriverUtil.getInputStreamFromPath(filePath);
             workbook = WorkbookFactory.create(fin);
         } catch (FileNotFoundException e) {
+            releaseLock();
             throw new SQLException("Could not locate the EXCEL datasource in the provided " +
                                    "location", e);
         } catch (IOException | InvalidFormatException e) {
+            releaseLock();
             throw new SQLException("Error occurred while initializing the EXCEL datasource", e);
         } catch (InterruptedException e) {
+            releaseLock();
             throw new SQLException("Error Acquiring the lock for the workbook path - " + filePath, e);
         }
         return workbook;

--- a/components/data-services/org.wso2.carbon.dataservices.sql.driver/src/main/java/org/wso2/carbon/dataservices/sql/driver/TExcelConnection.java
+++ b/components/data-services/org.wso2.carbon.dataservices.sql.driver/src/main/java/org/wso2/carbon/dataservices/sql/driver/TExcelConnection.java
@@ -82,6 +82,9 @@ public class TExcelConnection extends TConnection {
         } catch (InterruptedException e) {
             releaseLock();
             throw new SQLException("Error Acquiring the lock for the workbook path - " + filePath, e);
+        } catch (SQLException e) {
+            releaseLock();
+            throw e;
         }
         return workbook;
     }


### PR DESCRIPTION
This is to fix https://wso2.org/jira/browse/DS-1264
When an exception occurred while getting an excel workbook from the inputstream, the lock has to be released. Otherwise subsequent calls (when it tries to redeploy periodically) will be failed as they cannot acquire the lock.