### PR TITLE
Release lock when exception occured while creating connection to excel

### DIFF
--- a/components/data-services/org.wso2.carbon.dataservices.sql.driver/src/main/java/org/wso2/carbon/dataservices/sql/driver/TExcelConnection.java
+++ b/components/data-services/org.wso2.carbon.dataservices.sql.driver/src/main/java/org/wso2/carbon/dataservices/sql/driver/TExcelConnection.java
@@ -79,6 +79,8 @@ public class TExcelConnection extends TConnection {
             throw new SQLException("Error occurred while initializing the EXCEL datasource", e);
         } catch (InterruptedException e) {
             throw new SQLException("Error Acquiring the lock for the workbook path - " + filePath, e);
+        } finally {
+            releaseLock();
         }
         return workbook;
     }


### PR DESCRIPTION
This is to fix https://wso2.org/jira/browse/DS-1264
When an exception occurred while getting an excel workbook from the inputstream in query mode, the lock has to be released. Otherwise subsequent calls (when it tries to redeploy periodically) will be failed as they cannot acquire the lock.