### PR TITLE
Allow sufficient decimal points on a timestamp column when reading from OData service.

### DIFF
--- a/components/data-services/org.wso2.carbon.dataservices.core/src/main/java/org/wso2/carbon/dataservices/core/odata/ODataAdapter.java
+++ b/components/data-services/org.wso2.carbon.dataservices.core/src/main/java/org/wso2/carbon/dataservices/core/odata/ODataAdapter.java
@@ -1647,6 +1647,8 @@ public class ODataAdapter implements ServiceHandler {
                     property.setType(EdmPrimitiveTypeKind.DateTimeOffset.getFullQualifiedName());
                     property.setNullable(column.isNullable());
                     property.setMaxLength(column.getMaxLength());
+		    // Setting as 9 to support nano second representations from certain databases.
+                    property.setPrecision(9);
                     break;
                 case GUID:
                     property.setType(EdmPrimitiveTypeKind.Guid.getFullQualifiedName());


### PR DESCRIPTION
Fixes Issue : https://github.com/wso2/product-ei/issues/1196