### PR TITLE
Fix failure of AddScheduleTaskTestCase.startScheduleTask()

### DIFF
--- a/components/data-services/org.wso2.carbon.dataservices.task.ui/src/main/java/org/wso2/carbon/dataservices/task/ui/DSTaskManagementHelper.java
+++ b/components/data-services/org.wso2.carbon.dataservices.task.ui/src/main/java/org/wso2/carbon/dataservices/task/ui/DSTaskManagementHelper.java
@@ -68,7 +68,7 @@ public class DSTaskManagementHelper {
 		String interval = request.getParameter("triggerInterval");
 		if (interval != null && !"".equals(interval)) {
 			try {
-				dsTaskInfo.setTaskInterval(Integer.parseInt(interval.trim()));
+				dsTaskInfo.setTaskInterval(Long.parseLong(interval.trim()));
 			} catch (NumberFormatException e) {
 				handleException("Invalid value for interval (Expected type is integer) : "
 						+ interval);

--- a/components/data-services/org.wso2.carbon.dataservices.task/src/main/java/org/wso2/carbon/dataservices/task/DSTaskInfo.java
+++ b/components/data-services/org.wso2.carbon.dataservices.task/src/main/java/org/wso2/carbon/dataservices/task/DSTaskInfo.java
@@ -33,7 +33,7 @@ public class DSTaskInfo {
 	
 	private int taskCount;
 	
-	private int taskInterval;
+	private long taskInterval;
 	
 	private String cronExpression;
 	
@@ -78,11 +78,11 @@ public class DSTaskInfo {
 		this.taskCount = taskCount;
 	}
 
-	public int getTaskInterval() {
+	public long getTaskInterval() {
 		return taskInterval;
 	}
 
-	public void setTaskInterval(int taskInterval) {
+	public void setTaskInterval(long taskInterval) {
 		this.taskInterval = taskInterval;
 	}
 

--- a/pom.xml
+++ b/pom.xml
@@ -1275,7 +1275,7 @@
 
         <carbon.p2.plugin.version>1.5.5</carbon.p2.plugin.version>
 
-        <carbon-commons.version>4.6.3</carbon-commons.version>
+        <carbon-commons.version>4.6.8</carbon-commons.version>
         <carbon-commons.feature.imp.version>4.6.0</carbon-commons.feature.imp.version>
         <carbon-commons.imp.pkg.version>[4.5.0,5.0.0)</carbon-commons.imp.pkg.version>
         <carbon-commons.user.mgt.imp.pkg.version>0.0.0</carbon-commons.user.mgt.imp.pkg.version> <!-- todo remove this and use identity.imp.pkg.version - rajith (temparory done)-->

--- a/service-stubs/data-services/org.wso2.carbon.dataservices.task.stub/src/main/resources/DSTaskAdmin.wsdl
+++ b/service-stubs/data-services/org.wso2.carbon.dataservices.task.stub/src/main/resources/DSTaskAdmin.wsdl
@@ -12,7 +12,7 @@
                     <xs:element minOccurs="0" name="serviceName" nillable="true" type="xs:string" />
                     <xs:element minOccurs="0" name="startTime" nillable="true" type="xs:dateTime" />
                     <xs:element minOccurs="0" name="taskCount" type="xs:int" />
-                    <xs:element minOccurs="0" name="taskInterval" type="xs:int" />
+                    <xs:element minOccurs="0" name="taskInterval" type="xs:long" />
                 </xs:sequence>
             </xs:complexType>
         </xs:schema>


### PR DESCRIPTION
## Purpose
Resolves https://github.com/wso2/product-ei/issues/1407

## Goals
Fixes the failure of AddScheduleTaskTestCase.startScheduleTask() once the carbon.commons version is upgraed.

## Approach
Changed the usages of TaskInfo.setTaskInterval to pass a long value instead an integer.

## Documentation
n/a, This is a bug fix

## Related PRs
