### PR TITLE
Fix viewing secret alias viewed in mgt console

### DIFF
--- a/components/data-services/org.wso2.carbon.dataservices.ui/src/main/java/org/wso2/carbon/dataservices/ui/beans/Data.java
+++ b/components/data-services/org.wso2.carbon.dataservices.ui/src/main/java/org/wso2/carbon/dataservices/ui/beans/Data.java
@@ -488,7 +488,8 @@ public class Data extends DataServiceConfigurationElement{
                 } else {
                 	property.setName(name.getAttributeValue());
                 	if (name.getAttributeValue().equals(DBConstants.RDBMS.PASSWORD) || 
-                			name.getAttributeValue().equals(DBConstants.JNDI.PASSWORD) || 
+                			name.getAttributeValue().equals(DBConstants.JNDI.PASSWORD) ||
+                			name.getAttributeValue().equals(DBConstants.RDBMS_OLD.PASSWORD) ||
                 			name.getAttributeValue().equals(DBConstants.GSpread.PASSWORD)) {
                 		OMAttribute secretAlias = propertyEle.getAttribute(new QName(DBConstants.SECUREVAULT_NAMESPACE,"secretAlias"));
                     	if(secretAlias != null) {


### PR DESCRIPTION
## Purpose
> When creating a data service with dss tooling, if we create the password with secret Alias it is not getting populated in the management console.

## Goals
> Fix: https://github.com/wso2/product-ei/issues/1724