### PR TITLE
Close the dbs files FileInputStream after consumption

### DIFF
--- a/components/data-services/org.wso2.carbon.dataservices.core/src/main/java/org/wso2/carbon/dataservices/core/DBDeployer.java
+++ b/components/data-services/org.wso2.carbon.dataservices.core/src/main/java/org/wso2/carbon/dataservices/core/DBDeployer.java
@@ -296,16 +296,16 @@ public class DBDeployer extends AbstractDeployer {
     private String getServiceNameFromDSContents(File file) throws Exception {
         try (FileInputStream fis = new FileInputStream(file.getAbsoluteFile())) {
             StAXOMBuilder builder = new StAXOMBuilder(fis);
-			OMElement serviceEl = builder.getDocumentElement();
-			String serviceName = serviceEl.getAttributeValue(new QName(DBSFields.NAME));
-			builder.close();
-			if (DBUtils.isEmptyString(serviceName)) {
-				throw new DataServiceFault("Service group cannot be determined for the data service at '"
-						+ file.getAbsolutePath() + "'");
-			}
-			return serviceName;
-		}
-	}
+            OMElement serviceEl = builder.getDocumentElement();
+            String serviceName = serviceEl.getAttributeValue(new QName(DBSFields.NAME));
+            builder.close();
+            if (DBUtils.isEmptyString(serviceName)) {
+                throw new DataServiceFault("Service group cannot be determined for the data service at '"
+                        + file.getAbsolutePath() + "'");
+            }
+            return serviceName;
+        }
+    }
 
 	/**
 	 * Creates a timer with a one minute delay, for re-deploying a data service.
@@ -1185,7 +1185,7 @@ public class DBDeployer extends AbstractDeployer {
     private boolean handleSecurityProxy(DeploymentFileData file, AxisService axisService) throws DataServiceFault {
         try (FileInputStream fis = new FileInputStream(file.getFile().getAbsoluteFile())) {
             boolean secEnabled = false;
-			StAXOMBuilder builder = new StAXOMBuilder(fis);
+            StAXOMBuilder builder = new StAXOMBuilder(fis);
             OMElement documentElement =  builder.getDocumentElement();
             OMElement enableSecElement= documentElement.getFirstChildWithName(new QName(DBSFields.ENABLESEC));
             if (enableSecElement != null) {
@@ -1195,7 +1195,8 @@ public class DBDeployer extends AbstractDeployer {
             if (policyElement != null) {
                 String policyKey = policyElement.getAttributeValue(new QName(DBSFields.POLICY_KEY));
                 if (null == policyKey) {
-                    throw new DataServiceFault("Policy key element should contain a policy key in " + file.getFile().getName());
+                    throw new DataServiceFault("Policy key element should contain a policy key in "
+                            + file.getFile().getName());
                 }
                 Policy policy = PolicyEngine.getPolicy(DBUtils.getInputStreamFromPath(policyKey));
                 axisService.getPolicySubject().attachPolicy(policy);

--- a/components/data-services/org.wso2.carbon.dataservices.core/src/main/java/org/wso2/carbon/dataservices/core/DBDeployer.java
+++ b/components/data-services/org.wso2.carbon.dataservices.core/src/main/java/org/wso2/carbon/dataservices/core/DBDeployer.java
@@ -294,16 +294,18 @@ public class DBDeployer extends AbstractDeployer {
     }
 
     private String getServiceNameFromDSContents(File file) throws Exception {
-        StAXOMBuilder builder = new StAXOMBuilder(new FileInputStream(file.getAbsoluteFile()));
-        OMElement serviceEl = builder.getDocumentElement();
-        String serviceName = serviceEl.getAttributeValue(new QName(DBSFields.NAME));
-        builder.close();
-        if (DBUtils.isEmptyString(serviceName)) {
-            throw new DataServiceFault("Service group cannot be determined for the data service at '"
-                            + file.getAbsolutePath() + "'");
-        }
-        return serviceName;
-    }
+		try (FileInputStream fis = new FileInputStream(file.getAbsoluteFile())) {
+			StAXOMBuilder builder = new StAXOMBuilder(fis);
+			OMElement serviceEl = builder.getDocumentElement();
+			String serviceName = serviceEl.getAttributeValue(new QName(DBSFields.NAME));
+			builder.close();
+			if (DBUtils.isEmptyString(serviceName)) {
+				throw new DataServiceFault("Service group cannot be determined for the data service at '"
+						+ file.getAbsolutePath() + "'");
+			}
+			return serviceName;
+		}
+	}
 
 	/**
 	 * Creates a timer with a one minute delay, for re-deploying a data service.
@@ -1140,8 +1142,8 @@ public class DBDeployer extends AbstractDeployer {
 	 * "services.xml".
 	 */
 	private AxisService handleTransports(DeploymentFileData file, AxisService axisService) throws DataServiceFault {
-		try {
-            StAXOMBuilder builder = new StAXOMBuilder(new FileInputStream(file.getFile().getAbsoluteFile()));
+		try (FileInputStream fis = new FileInputStream(file.getFile().getAbsoluteFile())) {
+			StAXOMBuilder builder = new StAXOMBuilder(fis);
             OMElement documentElement =  builder.getDocumentElement();
             OMAttribute transports = documentElement.getAttribute(new QName(DBSFields.TRANSPORTS));
             if (transports != null) {
@@ -1181,9 +1183,9 @@ public class DBDeployer extends AbstractDeployer {
      * @throws DataServiceFault
      */
     private boolean handleSecurityProxy(DeploymentFileData file, AxisService axisService) throws DataServiceFault{
-        try {
+		try (FileInputStream fis = new FileInputStream(file.getFile().getAbsoluteFile())) {
             boolean secEnabled = false;
-            StAXOMBuilder builder = new StAXOMBuilder(new FileInputStream(file.getFile().getAbsoluteFile()));
+			StAXOMBuilder builder = new StAXOMBuilder(fis);
             OMElement documentElement =  builder.getDocumentElement();
             OMElement enableSecElement= documentElement.getFirstChildWithName(new QName(DBSFields.ENABLESEC));
             if (enableSecElement != null) {

--- a/components/data-services/org.wso2.carbon.dataservices.core/src/main/java/org/wso2/carbon/dataservices/core/DBDeployer.java
+++ b/components/data-services/org.wso2.carbon.dataservices.core/src/main/java/org/wso2/carbon/dataservices/core/DBDeployer.java
@@ -294,8 +294,8 @@ public class DBDeployer extends AbstractDeployer {
     }
 
     private String getServiceNameFromDSContents(File file) throws Exception {
-		try (FileInputStream fis = new FileInputStream(file.getAbsoluteFile())) {
-			StAXOMBuilder builder = new StAXOMBuilder(fis);
+        try (FileInputStream fis = new FileInputStream(file.getAbsoluteFile())) {
+            StAXOMBuilder builder = new StAXOMBuilder(fis);
 			OMElement serviceEl = builder.getDocumentElement();
 			String serviceName = serviceEl.getAttributeValue(new QName(DBSFields.NAME));
 			builder.close();
@@ -1182,8 +1182,8 @@ public class DBDeployer extends AbstractDeployer {
      * @return true if security is enabled, false otherwise.
      * @throws DataServiceFault
      */
-    private boolean handleSecurityProxy(DeploymentFileData file, AxisService axisService) throws DataServiceFault{
-		try (FileInputStream fis = new FileInputStream(file.getFile().getAbsoluteFile())) {
+    private boolean handleSecurityProxy(DeploymentFileData file, AxisService axisService) throws DataServiceFault {
+        try (FileInputStream fis = new FileInputStream(file.getFile().getAbsoluteFile())) {
             boolean secEnabled = false;
 			StAXOMBuilder builder = new StAXOMBuilder(fis);
             OMElement documentElement =  builder.getDocumentElement();


### PR DESCRIPTION
## Purpose
> Fix the issue which occurred when deleting files in Windows instances due to unclosed file input stream.

## Goals
> Use try-with-resources statement to declare FileInputStream.

## Approach
> Declare FileInputStream resource within try block, so the resource must be closed after the program is finished.

## User stories
> 

## Release note
> 

## Documentation
> 

## Training
> 

## Certification
> 

## Marketing
> 

## Automation tests
 - Integration tests

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> 

## Related PRs
> 

## Migrations (if applicable)
> 

## Test environment
> Windows 2016, Oracle JDK 8
 
## Learning
> 