### PR TITLE
Fix product-ei/issues/2812

### DIFF
--- a/components/data-services/org.wso2.carbon.dataservices.core/src/main/java/org/wso2/carbon/dataservices/core/DataServiceDocLitWrappedSchemaGenerator.java
+++ b/components/data-services/org.wso2.carbon.dataservices.core/src/main/java/org/wso2/carbon/dataservices/core/DataServiceDocLitWrappedSchemaGenerator.java
@@ -31,6 +31,7 @@ import org.wso2.carbon.dataservices.common.DBConstants;
 import org.wso2.carbon.dataservices.common.DBConstants.ResultTypes;
 import org.wso2.carbon.dataservices.core.description.operation.Operation;
 import org.wso2.carbon.dataservices.core.description.query.Query;
+import org.wso2.carbon.dataservices.core.description.query.SQLQuery;
 import org.wso2.carbon.dataservices.core.description.resource.Resource;
 import org.wso2.carbon.dataservices.core.description.resource.Resource.ResourceID;
 import org.wso2.carbon.dataservices.core.engine.*;
@@ -211,6 +212,7 @@ public class DataServiceDocLitWrappedSchemaGenerator {
 		AxisOperation axisOp = cparams.getAxisService().getOperation(new QName(requestName));
 		CallQuery callQuery = request.getCallQuery();
 		Query query = callQuery.getQuery();
+		boolean optional = false;
 		AxisMessage inMessage = axisOp.getMessage(WSDLConstants.MESSAGE_LABEL_IN_VALUE);
 		if (inMessage != null) {
                 inMessage.setName(requestName + Java2WSDLConstants.MESSAGE_SUFFIX);
@@ -255,9 +257,17 @@ public class DataServiceDocLitWrappedSchemaGenerator {
                                 }
                                 tmpEl = createInputEntryElement(cparams, query, queryParam,
                                         tmpWithParam);
+                                /* checking if query is SQL update query and for optional parameters*/
+                                if (callQuery.getQuery() instanceof SQLQuery
+                                   && ((SQLQuery) query).getSqlQueryType() == SQLQuery.QueryType.UPDATE
+                                   && queryParam.isOptional()) {
+                                   optional = true;
+                                } else {
+                                   optional = false;
+                                }
                                 /* add to input element complex type */
-                                addElementToComplexTypeSequence(cparams, inputComplexType,
-                                        query.getInputNamespace(), tmpEl, false, false, false);
+                                addElementToComplexTypeSequence(cparams, inputComplexType,query.getInputNamespace(),
+                                     tmpEl, false, false, optional);
                             }
                         }
                     } else {

--- a/components/data-services/org.wso2.carbon.dataservices.core/src/main/java/org/wso2/carbon/dataservices/core/DataServiceDocLitWrappedSchemaGenerator.java
+++ b/components/data-services/org.wso2.carbon.dataservices.core/src/main/java/org/wso2/carbon/dataservices/core/DataServiceDocLitWrappedSchemaGenerator.java
@@ -258,15 +258,11 @@ public class DataServiceDocLitWrappedSchemaGenerator {
                                 tmpEl = createInputEntryElement(cparams, query, queryParam,
                                         tmpWithParam);
                                 /* checking if query is SQL update query and for optional parameters*/
-                                if (callQuery.getQuery() instanceof SQLQuery
-                                   && ((SQLQuery) query).getSqlQueryType() == SQLQuery.QueryType.UPDATE
-                                   && queryParam.isOptional()) {
-                                   optional = true;
-                                } else {
-                                   optional = false;
-                                }
+                                optional = callQuery.getQuery() instanceof SQLQuery
+                                        && ((SQLQuery) query).getSqlQueryType() == SQLQuery.QueryType.UPDATE
+                                        && queryParam.isOptional();
                                 /* add to input element complex type */
-                                addElementToComplexTypeSequence(cparams, inputComplexType,query.getInputNamespace(),
+                                addElementToComplexTypeSequence(cparams, inputComplexType, query.getInputNamespace(),
                                      tmpEl, false, false, optional);
                             }
                         }

--- a/components/data-services/org.wso2.carbon.dataservices.core/src/main/java/org/wso2/carbon/dataservices/core/WSDLToDataService.java
+++ b/components/data-services/org.wso2.carbon.dataservices.core/src/main/java/org/wso2/carbon/dataservices/core/WSDLToDataService.java
@@ -360,7 +360,7 @@ public class WSDLToDataService {
 					prop.isArray() ? DBConstants.QueryParamTypes.ARRAY : 
 						DBConstants.QueryParamTypes.SCALAR, 
 					i + 1, // ordinal
-					null, null, new ArrayList<Validator>(), false));
+					null, null, new ArrayList<Validator>(), false, false));
 		}
 
 		return queryParams;

--- a/components/data-services/org.wso2.carbon.dataservices.core/src/main/java/org/wso2/carbon/dataservices/core/description/query/ExpressionQuery.java
+++ b/components/data-services/org.wso2.carbon.dataservices.core/src/main/java/org/wso2/carbon/dataservices/core/description/query/ExpressionQuery.java
@@ -242,21 +242,23 @@ public abstract class ExpressionQuery extends Query {
         int count;
         for (int i = 1; i <= paramCount; i++) {
             param = params.getParam(i);
-            value = param.getValue();
-			/*
-			 * value can be null in stored proc OUT params, so it is simply
-			 * treated as a single param, because the number of elements in an
-			 * array cannot be calculated, since there's no actual value passed
-			 * in
-			 */
-            if (value != null && (value.getValueType() == ParamValue.PARAM_VALUE_ARRAY)) {
-                count = (value.getArrayValue()).size();
-            } else {
-                count = 1;
+            if (param != null) {
+                value = param.getValue();
+                /*
+                 * value can be null in stored proc OUT params, so it is simply
+                 * treated as a single param, because the number of elements in an
+                 * array cannot be calculated, since there's no actual value passed
+                 * in
+                 */
+                if (value != null && (value.getValueType() == ParamValue.PARAM_VALUE_ARRAY)) {
+                    count = (value.getArrayValue()).size();
+                } else {
+                    count = 1;
+                }
+                vals = this.expandQuery(start, count, currentQuery);
+                start = (Integer) vals[0];
+                currentQuery = (String) vals[1];
             }
-            vals = this.expandQuery(start, count, currentQuery);
-            start = (Integer) vals[0];
-            currentQuery = (String) vals[1];
         }
         return currentQuery;
     }
@@ -310,18 +312,25 @@ public abstract class ExpressionQuery extends Query {
      */
     protected Object[] processDynamicQuery(String query, InternalParamCollection params) {
         Integer[] paramIndices = this.extractQueryParamIndices(query);
+        Map<Integer, QueryParam> tempParams = new HashMap<>();
         int currentOrdinalDiff = 0;
         int currentParamIndexDiff = 0;
         InternalParam tmpParam;
         int paramIndex;
         String tmpValue;
         int resultParamCount = paramCount;
+        for (QueryParam queryParam : this.getQueryParams()) {
+            tempParams.put(queryParam.getOrdinal(), queryParam);
+        }
         for (int i = 1; i <= paramCount; i++) {
             tmpParam = params.getParam(i);
-            if (tmpParam == null) {
+            if (tmpParam == null && !(((SQLQuery)this).getSqlQueryType() == SQLQuery.QueryType.UPDATE)) {
                 throw new RuntimeException("Parameters are not Defined Correctly, missing parameter ordinal - " + i);
             }
-            if (DBConstants.DataTypes.QUERY_STRING.equals(tmpParam.getSqlType())) {
+            if (tmpParam == null && !(tempParams.get(i).isOptional())) {
+                throw new RuntimeException("Parameters are not Defined Correctly, missing parameter ordinal - " + i);
+            }
+            if (tmpParam != null && !(tempParams.get(i).isOptional()) && DBConstants.DataTypes.QUERY_STRING.equals(tmpParam.getSqlType())) {
                 paramIndex = paramIndices[i - 1] + currentParamIndexDiff;
                 tmpValue = params.getParam(i).getValue().getScalarValue();
                 currentParamIndexDiff += tmpValue.length() - 1;
@@ -334,9 +343,11 @@ public abstract class ExpressionQuery extends Query {
                 currentOrdinalDiff++;
                 resultParamCount--;
             } else {
-                params.remove(i);
-                tmpParam.setOrdinal(i - currentOrdinalDiff);
-                params.addParam(tmpParam);
+                if (params.getParam(i) != null) {
+                    params.remove(i);
+                    tmpParam.setOrdinal(i - currentOrdinalDiff);
+                    params.addParam(tmpParam);
+                }
             }
         }
         return new Object[] { query, resultParamCount };

--- a/components/data-services/org.wso2.carbon.dataservices.core/src/main/java/org/wso2/carbon/dataservices/core/description/query/Query.java
+++ b/components/data-services/org.wso2.carbon.dataservices.core/src/main/java/org/wso2/carbon/dataservices/core/description/query/Query.java
@@ -213,11 +213,15 @@ public abstract class Query extends XMLWriterHelper {
 						QueryTypes.INOUT.equals(queryParam.getType()))) {
 					/* check the exported values */
 					tmpParamValue = exportedParams.get(queryParam.getName());
-					if (tmpParamValue == null && !queryParam.hasDefaultValue()) {
+					if (queryParam.isOptional()) {
+						continue;
+					} else {
+						if (tmpParamValue == null && !queryParam.hasDefaultValue()) {
 						/* still can't find, throw an exception */
-						throw new DataServiceFault(FaultCodes.INCOMPATIBLE_PARAMETERS_ERROR,
-								"Error in 'Query.extractParams', " +
+							throw new DataServiceFault(FaultCodes.INCOMPATIBLE_PARAMETERS_ERROR,
+							"Error in 'Query.extractParams', " +
 								"cannot find query param with name:" + queryParam.getName());
+						}
 					}
 				}
 			}

--- a/components/data-services/org.wso2.carbon.dataservices.core/src/main/java/org/wso2/carbon/dataservices/core/description/query/QueryFactory.java
+++ b/components/data-services/org.wso2.carbon.dataservices.core/src/main/java/org/wso2/carbon/dataservices/core/description/query/QueryFactory.java
@@ -1071,9 +1071,10 @@ public class QueryFactory {
 		OMElement paramEl;
 		String name, sqlType, type, paramType, ordinalStr, defaultValue, structType;
 		int ordinal, currentTmpOrdinal = 0;
-		boolean forceDefault = false;
+		boolean forceDefault, optional = false;
 		while (paramItr.hasNext()) {
-			forceDefault = false;
+			forceDefault  = false;
+			optional  = false;
 			paramEl = paramItr.next();
 			name = paramEl.getAttributeValue(new QName(DBSFields.NAME));
             if (name != null) {
@@ -1100,13 +1101,16 @@ public class QueryFactory {
 			if (paramEl.getAttributeValue(new QName(DBSFields.FORCED_DEFAULT)) != null) {
 			    forceDefault = Boolean.parseBoolean(paramEl.getAttributeValue(new QName(DBSFields.FORCED_DEFAULT)));
 			}
+			if (paramEl.getAttributeValue(new QName(DBSFields.OPTIONAL)) != null) {
+				optional = Boolean.parseBoolean(paramEl.getAttributeValue(new QName(DBSFields.OPTIONAL)));
+			}
 			/* retrieve validators */
 			List<Validator> validators = getValidators(paramType, paramEl);
             /* retrieve struct type  */
             structType = paramEl.getAttributeValue(new QName(DBSFields.STRUCT_TYPE));
 			queryParams.add(new QueryParam(name, sqlType, type, paramType, ordinal,
                     defaultValue == null ? null : new ParamValue(defaultValue), structType,
-                    validators, forceDefault));
+                    validators, forceDefault, optional));
 		}
 		
 		return queryParams;

--- a/components/data-services/org.wso2.carbon.dataservices.core/src/main/java/org/wso2/carbon/dataservices/core/description/query/SQLQuery.java
+++ b/components/data-services/org.wso2.carbon.dataservices.core/src/main/java/org/wso2/carbon/dataservices/core/description/query/SQLQuery.java
@@ -2525,7 +2525,7 @@ public class SQLQuery extends ExpressionQuery implements BatchRequestParticipant
     public static QueryType sqlQueryType(String sqlQuery) {
 
         String query = sqlQuery.substring(0, sqlQuery.indexOf(" ")).toUpperCase();
-        ;
+        
         switch (query) {
             case "UPDATE":
                 sqlQueryType = QueryType.UPDATE;

--- a/components/data-services/org.wso2.carbon.dataservices.core/src/main/java/org/wso2/carbon/dataservices/core/description/query/SQLQuery.java
+++ b/components/data-services/org.wso2.carbon.dataservices.core/src/main/java/org/wso2/carbon/dataservices/core/description/query/SQLQuery.java
@@ -45,6 +45,7 @@ import org.wso2.carbon.dataservices.core.engine.ParamValue;
 import org.wso2.carbon.dataservices.core.engine.QueryParam;
 import org.wso2.carbon.dataservices.core.engine.Result;
 import org.wso2.carbon.dataservices.core.engine.ResultSetWrapper;
+import org.wso2.carbon.dataservices.core.sqlparser.LexicalConstants;
 
 import javax.xml.stream.XMLStreamWriter;
 import java.io.BufferedReader;
@@ -74,7 +75,9 @@ import java.sql.Timestamp;
 import java.sql.Types;
 import java.text.ParseException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Calendar;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.TimeZone;
@@ -146,6 +149,8 @@ public class SQLQuery extends ExpressionQuery implements BatchRequestParticipant
 
     private boolean timeConvertEnabled = true;
 
+    private static QueryType sqlQueryType;
+
     /**
      * thread local variable to keep the ordinal of the ref cursor if there is any
      */
@@ -191,6 +196,8 @@ public class SQLQuery extends ExpressionQuery implements BatchRequestParticipant
     @Override
     public void init(String query) throws DataServiceFault {
         super.init(query);
+        /*check for the type of query executed ie: UPDATE, INSERT, DELETE, SELECT*/
+        this.setSqlQueryType(query);
         /* process the advanced/additional properties */
         this.processAdvancedProps(this.getAdvancedProperties());
         this.queryType = this.retrieveQueryType(this.getQuery());
@@ -249,7 +256,7 @@ public class SQLQuery extends ExpressionQuery implements BatchRequestParticipant
 
     /**
      * Extract the stored proc name from the SQL.
-     * 
+     *
      * @param skipFirstWord
      *            If the first word should be considered the name or not, if
      *            this is true, the second word will be considered as the stored
@@ -1380,6 +1387,26 @@ public class SQLQuery extends ExpressionQuery implements BatchRequestParticipant
     private PreparedStatement createProcessedPreparedStatement(int queryType,
             InternalParamCollection params, Connection conn) throws DataServiceFault {
         try {
+            /*Creating a new update query based on the parameters passed in the payload, checking whether the missing
+             parameters are optional*/
+            String query = this.getQuery();
+
+            boolean hasOptional = false;
+            for (QueryParam queryParam : this.getQueryParams()) {
+                if (queryParam.isOptional()) {
+                    hasOptional = true;
+                    break;
+                }
+            }
+
+            if (getSqlQueryType() == QueryType.UPDATE && hasOptional) {
+                query = generateSQLupdateQuery(params, query);
+            }
+
+            String paramsStr1 = "";
+            for (int i = 1; i <= this.getParamCount(); i++) {
+                paramsStr1 = paramsStr1 + params.getParam(i) + ",";
+            }
             /*
              * lets see first if there's already a batch prepared statement
              * created
@@ -1391,7 +1418,7 @@ public class SQLQuery extends ExpressionQuery implements BatchRequestParticipant
             /* create a new prepared statement */
             if (stmt == null) {
                 /* batch mode is not supported for dynamic queries */
-                Object[] result = this.processDynamicQuery(this.getQuery(), params);
+                Object[] result = this.processDynamicQuery(query, params);
                 String dynamicSQL = (String) result[0];
                 currentParamCount = (Integer) result[1];
                 String processedSQL = this.createProcessedQuery(dynamicSQL, params, currentParamCount);
@@ -1467,24 +1494,26 @@ public class SQLQuery extends ExpressionQuery implements BatchRequestParticipant
             ParamValue value;
             for (int i = 1; i <= currentParamCount; i++) {
                 param = params.getParam(i);
-                value = param.getValue();
-                /*
-                 * handle array values, if value is null, this param has to be
-                 * an OUT param
-                 */
-                param.setOrdinal(currentOrdinal + 1);
-                if (value != null && value.getValueType() == ParamValue.PARAM_VALUE_ARRAY) {
-                    for (ParamValue arrayElement : value.getArrayValue()) {
-                        this.setParamInPreparedStatement(
-                                stmt, param, arrayElement == null ? null : arrayElement.toString(),
-                                queryType, currentOrdinal);
+                if (params.getParam(i) != null) {
+                    value = param.getValue();
+                    /*
+                     * handle array values, if value is null, this param has to be
+                     * an OUT param
+                     */
+                    param.setOrdinal(currentOrdinal + 1);
+                    if (value != null && value.getValueType() == ParamValue.PARAM_VALUE_ARRAY) {
+                        for (ParamValue arrayElement : value.getArrayValue()) {
+                            this.setParamInPreparedStatement(
+                                    stmt, param, arrayElement == null ? null : arrayElement.toString(),
+                                    queryType, currentOrdinal);
+                            currentOrdinal++;
+                        }
+                    } else { /* scalar value */
+                        this.setParamInPreparedStatement(stmt, param,
+                                value != null ? value.getScalarValue() : null, queryType,
+                                currentOrdinal);
                         currentOrdinal++;
                     }
-                } else { /* scalar value */
-                    this.setParamInPreparedStatement(stmt, param,
-                            value != null ? value.getScalarValue() : null, queryType,
-                            currentOrdinal);
-                    currentOrdinal++;
                 }
             }
 
@@ -1497,6 +1526,91 @@ public class SQLQuery extends ExpressionQuery implements BatchRequestParticipant
         } catch (SQLException e) {
             throw new DataServiceFault(e, "Error in 'createProcessedPreparedStatement'");
         }
+    }
+
+    private String generateSQLupdateQuery(InternalParamCollection params, String query) {
+
+        String referenceName = "";
+        boolean containsRefrenceName = false;
+        StringBuilder updateFeilds = new StringBuilder();
+        StringBuilder sqlQuery = new StringBuilder();
+        StringBuilder userDefinedColumnsInQuery = new StringBuilder();
+        String tableName = query.split("\\s")[1];
+        ArrayList<String> definedColumnsInQuery;
+        ArrayList<String> columnsInQuery;
+        Iterator<String> iter;
+        boolean isHavingWhereClause = false;
+        String queryAfterWhere = "";
+        int indexOfWhere;
+        int indexOfSet;
+
+        indexOfWhere = query.indexOf(LexicalConstants.WHERE);
+        if (indexOfWhere == -1) {
+            indexOfWhere = query.indexOf(LexicalConstants.WHERE.toLowerCase());
+        }
+        if (indexOfWhere != -1) {
+            isHavingWhereClause = true;
+            queryAfterWhere = query.substring(indexOfWhere + 5);
+        }
+        indexOfSet = query.indexOf(LexicalConstants.SET);
+        if (indexOfSet == -1) {
+            indexOfSet = query.indexOf(LexicalConstants.SET.toLowerCase());
+        }
+        if (!isHavingWhereClause) {
+            indexOfWhere = query.length();
+        }
+        //obtaining columns to be updated to an array list.
+        definedColumnsInQuery = new ArrayList<String>(
+                Arrays.asList(query.substring(indexOfSet + 3, indexOfWhere).replaceAll(" ", "").split(",")));
+        columnsInQuery = new ArrayList<>(definedColumnsInQuery);
+        iter = definedColumnsInQuery.iterator();
+
+        while (iter.hasNext()) {
+            String col = iter.next();
+            if (col.contains("?")) {//all columns reqiring parameters are defined as "FirstName=?" therefore user
+                // parameter requiring columns can be removed and the explicitly defined update column swill remain
+                // in the list and can be add later at the end of the query.
+                iter.remove();
+            }
+        }
+
+        while (iter.hasNext()) {
+            userDefinedColumnsInQuery.append(iter.next()).append(",");
+        }
+
+        if (!LexicalConstants.SET.equalsIgnoreCase(query.split("\\s")[2])) {
+            //obataining the referance name to the table if provided in the query
+            containsRefrenceName = true;
+            referenceName = query.split("\\s")[3];
+        }
+
+        for (InternalParam param : params.getParams()) {
+            //checking if the user provided parameter is given in the list of parameters to be updated
+            if (columnsInQuery.contains(param.getName() + "=?")) {
+                if (containsRefrenceName) {
+                    //adding update columns to the update string
+                    updateFeilds.append(" ").append(referenceName).append(".").append(param.getName()).append(" =? ,");
+                } else {
+                    updateFeilds.append(" ").append(param.getName()).append(" =? ,");
+                }
+            }
+        }
+        updateFeilds.append(" ").append(userDefinedColumnsInQuery);//adding the explicitly defined columns and values
+        updateFeilds = new StringBuilder(updateFeilds.substring(0, updateFeilds.lastIndexOf(",")));
+
+        if (isHavingWhereClause) {//checking if the user defined query contains a "WHERE" clause and adds accordingly
+            // the query part after the where clause from the user defined query
+            sqlQuery.append(LexicalConstants.UPDATE).append(" ").append(tableName).append(" ")
+                    .append(LexicalConstants.SET).append(" ").append(updateFeilds).append(" ")
+                    .append(LexicalConstants.WHERE).append(" ").append(queryAfterWhere);
+            return sqlQuery.toString();
+
+        } else {
+            sqlQuery.append(LexicalConstants.UPDATE).append(" ").append(tableName).append(" ")
+                    .append(LexicalConstants.SET).append(" ").append(updateFeilds);
+            return sqlQuery.toString();
+        }
+
     }
 
     private void setParamInPreparedStatement(PreparedStatement stmt, InternalParam param,
@@ -2396,6 +2510,44 @@ public class SQLQuery extends ExpressionQuery implements BatchRequestParticipant
         public int getFetchSize() {
             return fetchSize;
         }
+    }
+
+    public QueryType getSqlQueryType() {
+
+        return sqlQueryType;
+    }
+
+    public QueryType setSqlQueryType(String query) {
+
+        return sqlQueryType = sqlQueryType(query);
+    }
+
+    public static QueryType sqlQueryType(String sqlQuery) {
+
+        String query = sqlQuery.substring(0, sqlQuery.indexOf(" ")).toUpperCase();
+        ;
+        switch (query) {
+            case "UPDATE":
+                sqlQueryType = QueryType.UPDATE;
+                break;
+            case "SELECT":
+                sqlQueryType = QueryType.SELECT;
+                break;
+            case "DELETE":
+                sqlQueryType = QueryType.DELETE;
+                break;
+            case "INSERT":
+                sqlQueryType = QueryType.INSERT;
+                break;
+        }
+        return sqlQueryType;
+    }
+
+    public enum QueryType {
+        UPDATE,
+        INSERT,
+        DELETE,
+        SELECT;
     }
 
 }

--- a/components/data-services/org.wso2.carbon.dataservices.core/src/main/java/org/wso2/carbon/dataservices/core/engine/CallQuery.java
+++ b/components/data-services/org.wso2.carbon.dataservices.core/src/main/java/org/wso2/carbon/dataservices/core/engine/CallQuery.java
@@ -26,6 +26,7 @@ import org.wso2.carbon.dataservices.common.DBConstants.DBSFields;
 import org.wso2.carbon.dataservices.common.DBConstants.FaultCodes;
 import org.wso2.carbon.dataservices.core.DataServiceFault;
 import org.wso2.carbon.dataservices.core.description.query.Query;
+import org.wso2.carbon.dataservices.core.description.query.SQLQuery;
 
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamWriter;
@@ -328,6 +329,11 @@ public class CallQuery extends OutputElement {
 			} else if (params.getTempEntries().containsKey(withParam.getName())) {
 				/* this means the query param will be added later by the default values */
 				continue;
+			} else if (queryParamMap.get(paramName) != null
+					&& this.getQuery() instanceof SQLQuery
+					&& ((SQLQuery)this.query).getSqlQueryType() == SQLQuery.QueryType.UPDATE
+					&& queryParamMap.get(paramName).isOptional()) {
+						continue;
 			} else {
 				throw new DataServiceFault(FaultCodes.INCOMPATIBLE_PARAMETERS_ERROR,
 						"Error in 'CallQuery.extractParams', cannot find parameter with type:" +

--- a/components/data-services/org.wso2.carbon.dataservices.core/src/main/java/org/wso2/carbon/dataservices/core/engine/QueryParam.java
+++ b/components/data-services/org.wso2.carbon.dataservices.core/src/main/java/org/wso2/carbon/dataservices/core/engine/QueryParam.java
@@ -170,11 +170,11 @@ public class QueryParam {
 	return forceDefault;
     }
 
-	public boolean isOptional() {
+    public boolean isOptional() {
 	return optional;
 	}
 
-	public boolean hasDefaultValue() {
+    public boolean hasDefaultValue() {
     	return this.getDefaultValue() != null;
     }
 

--- a/components/data-services/org.wso2.carbon.dataservices.core/src/main/java/org/wso2/carbon/dataservices/core/engine/QueryParam.java
+++ b/components/data-services/org.wso2.carbon.dataservices.core/src/main/java/org/wso2/carbon/dataservices/core/engine/QueryParam.java
@@ -61,10 +61,12 @@ public class QueryParam {
     private String structType;
 
     private boolean forceDefault;
-	
-	public QueryParam(String name, String sqlType, String type, String paramType, 
+
+    private boolean optional;
+
+	public QueryParam(String name, String sqlType, String type, String paramType,
 			int ordinal, ParamValue defaultValue, String structType,
-			List<Validator> validators, boolean forceDefault) throws DataServiceFault {
+			List<Validator> validators, boolean forceDefault, boolean optional) throws DataServiceFault {
 		this.name = name;
 		this.sqlType = sqlType;
 		this.type = type;
@@ -75,6 +77,7 @@ public class QueryParam {
         this.structType = structType;
         this.validators = validators;
         this.forceDefault = forceDefault;
+        this.optional = optional;
         /* validate the current query param */
         this.validateQueryParam();
 	}
@@ -167,7 +170,11 @@ public class QueryParam {
 	return forceDefault;
     }
 
-    public boolean hasDefaultValue() {
+	public boolean isOptional() {
+	return optional;
+	}
+
+	public boolean hasDefaultValue() {
     	return this.getDefaultValue() != null;
     }
 

--- a/components/data-services/org.wso2.carbon.dataservices.core/src/main/java/org/wso2/carbon/dataservices/core/script/DSGenerator.java
+++ b/components/data-services/org.wso2.carbon.dataservices.core/src/main/java/org/wso2/carbon/dataservices/core/script/DSGenerator.java
@@ -851,7 +851,7 @@ public class DSGenerator {
 			}
 			List<Validator> validator = new ArrayList<Validator>();
 			QueryParam queryParam = new QueryParam(pName, sqlType, DBConstants.DataServiceGenerator.IN,
-					DBConstants.DataServiceGenerator.SCALAR, ordinal, null, null, validator, false);
+					DBConstants.DataServiceGenerator.SCALAR, ordinal, null, null, validator, false, false);
 			paramList.add(queryParam);
 			ordinal++; // increase the ordinal value one by one
 		}

--- a/components/data-services/org.wso2.carbon.dataservices.ui/src/main/java/org/wso2/carbon/dataservices/ui/beans/Data.java
+++ b/components/data-services/org.wso2.carbon.dataservices.ui/src/main/java/org/wso2/carbon/dataservices/ui/beans/Data.java
@@ -1329,7 +1329,8 @@ public class Data extends DataServiceConfigurationElement{
 						userSetOrdinalValue,
                         paramElement.getAttributeValue(new QName("defaultValue")),
                         paramElement.getAttributeValue(new QName("structType")),
-                        this.getValidators(paramElement.getChildElements())
+                        this.getValidators(paramElement.getChildElements()),
+                        paramElement.getAttributeValue(new QName("optional"))
                         );
 			paramList.add(param);
 		}

--- a/components/data-services/org.wso2.carbon.dataservices.ui/src/main/java/org/wso2/carbon/dataservices/ui/beans/Param.java
+++ b/components/data-services/org.wso2.carbon.dataservices.ui/src/main/java/org/wso2/carbon/dataservices/ui/beans/Param.java
@@ -46,7 +46,9 @@ public class Param extends DataServiceConfigurationElement {
     private String structType;
 
     private List<Validator> validators;
-	
+
+	private String optional;
+
 	public String getName() {
 		return name;
 	}
@@ -111,8 +113,12 @@ public class Param extends DataServiceConfigurationElement {
         this.structType = structType;
     }
 
-    public Param(String name, String paramType, String sqlType, String type, String ordinal,
-                 String defaultValue, String structType, List<Validator> validators){
+	public String getOptional() { return optional; }
+
+	public void setOptional(String optional) { this.optional = optional; }
+
+	public Param(String name, String paramType, String sqlType, String type, String ordinal,
+				 String defaultValue, String structType, List<Validator> validators, String optional){
 		this.name = name;
 		this.sqlType = sqlType;
 		this.type = type;
@@ -129,11 +135,12 @@ public class Param extends DataServiceConfigurationElement {
         this.defaultValue = defaultValue;
         this.structType = structType;
         this.validators = validators;
+        this.optional = optional;
 	}
 	
 	public Param(String name, String paramType, String sqlType, String type, String defaultValue,
-                 List<Validator> validators){
-		this(name, paramType, sqlType, type, "0", defaultValue, null, validators);
+                 List<Validator> validators, String optional){
+		this(name, paramType, sqlType, type, "0", defaultValue, null, validators, optional);
 	}
 
     public Param() {
@@ -180,6 +187,9 @@ public class Param extends DataServiceConfigurationElement {
         if (this.getStructType() != null) {
             paramEl.addAttribute("structType", this.getStructType(), null);
         }
+		if (this.getOptional() != null) {
+			paramEl.addAttribute("optional", this.getOptional(), null);
+		}
         if (this.getValidators() != null) {
             for (Validator val : this.getValidators()) {
                 paramEl.addChild(val.buildXML());

--- a/components/data-services/org.wso2.carbon.dataservices.ui/src/main/java/org/wso2/carbon/dataservices/ui/beans/Query.java
+++ b/components/data-services/org.wso2.carbon.dataservices.ui/src/main/java/org/wso2/carbon/dataservices/ui/beans/Query.java
@@ -310,7 +310,8 @@ public class Query extends DataServiceConfigurationElement {
 					paramElement.getAttributeValue(new QName("sqlType")),
 					paramElement.getAttributeValue(new QName("type")), userSetOrdinalValue,
 					paramElement.getAttributeValue(new QName("defaultValue")),
-					this.getValidators(paramElement.getChildren()));
+					this.getValidators(paramElement.getChildren()),
+					paramElement.getAttributeValue(new QName("optional")));
 			paramList.add(param);
 		}
 		try {

--- a/components/data-services/org.wso2.carbon.dataservices.ui/src/main/resources/org/wso2/carbon/dataservices/ui/i18n/Resources.properties
+++ b/components/data-services/org.wso2.carbon.dataservices.ui/src/main/resources/org/wso2/carbon/dataservices/ui/i18n/Resources.properties
@@ -456,6 +456,7 @@ complex.element=Complex Element
 data.services.xsdType=Schema Type
 data.services.add.query=Add Query
 dataservices.param.type=Parameter Type
+dataservices.param.optional=Optional
 dataservices.default.value=Default Value
 dataservices.add.validations=Add Validations
 dataservices.validation.type=Validation Type

--- a/components/data-services/org.wso2.carbon.dataservices.ui/src/main/resources/web/ds/addInputMapping.jsp
+++ b/components/data-services/org.wso2.carbon.dataservices.ui/src/main/resources/web/ds/addInputMapping.jsp
@@ -40,6 +40,7 @@
     String defaultValue = request.getParameter("defaultValue");
     String structType = request.getParameter("structType");
     String ordinalVal = request.getParameter("inputMappingOrdinalId");
+    String optional = request.getParameter("optional");
     String caption;
     boolean isEdit = false;
     Query query = null;
@@ -64,6 +65,7 @@
             paramType = param.getParamType();
             defaultValue = param.getDefaultValue();
             structType = param.getStructType();
+            optional = param.getOptional();
             if (ordinal != 0) { //ordinal=0 when user not given a ordinal.
                 ordinalStr = Integer.toString(ordinal);
             }
@@ -78,6 +80,7 @@
     sqlType = (sqlType == null) ? "" : sqlType;
     inOutType = (inOutType == null) ? "" : inOutType;
     ordinalStr = (ordinalStr == null) ? "" : ordinalStr;
+    optional = (optional == null) ? "" : optional;
     if (!paramName.equals("")) {
         caption = "save";
     } else {
@@ -157,6 +160,18 @@
         <%} else {%>
         <option id="paramTypeArrayOptionId" disabled value="ARRAY">ARRAY</option>
         <% } %>
+        <% } %>
+    </select></td>
+</tr>
+<tr>
+    <td class="leftCol-small"><fmt:message key="dataservices.param.optional"/></td>
+    <td><select id="optionalId" name="optional">
+        <% if (optional.equalsIgnoreCase("false") || optional.equalsIgnoreCase("")) { %>
+        <option value="false" selected="selected">False</option>
+        <option value="true">True</option>
+        <% } else if (optional.equalsIgnoreCase("true")) { %>
+        <option value="true" selected="selected">True</option>
+        <option value="false">False</option>
         <% } %>
     </select></td>
 </tr>

--- a/components/data-services/org.wso2.carbon.dataservices.ui/src/main/resources/web/ds/inputMappingProcessor.jsp
+++ b/components/data-services/org.wso2.carbon.dataservices.ui/src/main/resources/web/ds/inputMappingProcessor.jsp
@@ -43,6 +43,7 @@
     String valPattern = request.getParameter("pattern");
     String valCustomClass = request.getParameter("customClass");
     String structType = request.getParameter("structType");
+    String optional = request.getParameter("optional");
     String dsValidatorProperties = request.getParameter("dsValidatorProperties");
     paramType = (paramType == null ) ? "SCALAR" : paramType;
     sqlType = (sqlType == null) ? "" : sqlType;
@@ -141,6 +142,7 @@
                                      param.setParamType(paramType);
                                      param.setSqlType(sqlType);
                                      param.setType(inOutType);
+                                     param.setOptional(optional);
                                      /*if( flag.equals("deleteValidator")) {
                                          validators.remove(validateElementName);
                                      }*/
@@ -170,6 +172,7 @@
                             param.setType(inOutType);
                             param.setParamType(paramType);
                             param.setValidarors(validators);
+                            param.setOptional(optional);
                             if(defaultValue != null && defaultValue.trim().length() > 0){
                                 param.setDefaultValue(defaultValue);
                             }


### PR DESCRIPTION
## Purpose
> Enable user to execute SQL update query based on the number of parameters passed in the payload. If parameters are not included in the payload but required in the SQL query, the query-param should contain attribute "optional = true".

Fixes : https://github.com/wso2/product-ei/issues/2812
## Goals
> Enable user to execute SQL update query based on the parameters passed in the payload.

## Approach
> Introduced attribute "optional" if true, the parameter required in SQL update query is optional in the payload. Read for optional attribute in the created .dbs file. Bypassed checking for parameters included in payload against the parameters required in the SQL query by checking for "optional" attribute.

> Generated SQL update query based on the parameters passed in the payload by checking with the defined SQL query without altering the whole query.

> Modified user interface (.jsp pages) in order for user to select the optional attribute when generating/creating input parameters.
