### PR TITLE
Fix for Issue #3314 URL parsing error

### DIFF
--- a/components/data-services/org.wso2.carbon.dataservices.core/src/main/java/org/wso2/carbon/dataservices/core/odata/RDBMSDataHandler.java
+++ b/components/data-services/org.wso2.carbon.dataservices.core/src/main/java/org/wso2/carbon/dataservices/core/odata/RDBMSDataHandler.java
@@ -1016,6 +1016,12 @@ public class RDBMSDataHandler implements ODataDataHandler {
         try {
             if (meta.getDatabaseProductName().toLowerCase().contains(ORACLE_SERVER)) {
                 resultSet = meta.getColumns(null, meta.getUserName(), tableName, null);
+                if (meta.getConnection().getSchema() != null) {
+                    if (!meta.getConnection().getSchema().equals(meta.getUserName())) {
+                        resultSet = meta.getColumns(null, meta.getConnection().getSchema(), tableName,
+                                null);
+                    }
+                }
             } else {
                 resultSet = meta.getColumns(null, null, tableName, null);
             }
@@ -1110,6 +1116,17 @@ public class RDBMSDataHandler implements ODataDataHandler {
             while (rs.next()) {
                 String tableName = rs.getString(TABLE_NAME);
                 tableList.add(tableName);
+            }
+            if (connection.getSchema() != null) {
+                if (meta.getDatabaseProductName().toLowerCase().contains(ORACLE_SERVER) && !connection.getSchema().
+                        equals(meta.getUserName())) {
+                    rs = meta.getTables(null, connection.getSchema(), null,
+                            new String[] { TABLE, VIEW });
+                    while (rs.next()) {
+                        String tableName = rs.getString(TABLE_NAME);
+                        tableList.add(tableName);
+                    }
+                }
             }
             return tableList;
         } catch (SQLException e) {


### PR DESCRIPTION
## Purpose
When doing an OData Request with postman or curl on an object belongs to another schema an empty metadata object is returned and when trying to access a table an URL parsing error "Unexpected start of resource-path segment" is thrown. This PR fixes this issue

## Changes
Made changes to readTableColumnMetaData() and generateTableList() 

Resolves issue : https://github.com/wso2/product-ei/issues/3314