### PR TITLE
Encode the resource path of dataservice

### DIFF
--- a/components/data-services/org.wso2.carbon.dataservices.ui/src/main/resources/web/ds/js/ui-validations.js
+++ b/components/data-services/org.wso2.carbon.dataservices.ui/src/main/resources/web/ds/js/ui-validations.js
@@ -1149,7 +1149,8 @@ function deleteQuery(obj){
 
 function deleteResources(objPath, objMethod){
     function forwardToDel() {
-        var url = 'resourceProcessor.jsp?action=remove&oldResourcePath='+objPath+'&oldResourceMethod='+objMethod;
+        var url = 'resourceProcessor.jsp?action=remove&oldResourcePath=' + encodeURIComponent(objPath)
+            + '&oldResourceMethod=' + objMethod;
         document.location.href = url;
     }
     CARBON.showConfirmationDialog('Do you want to delete resource '+objPath+'?', forwardToDel);


### PR DESCRIPTION
## Purpose
> Encode resource path to avoid malformed URL issue.

## Goals
> should be able to delete resources like getAllRows/{lahiru}

## Approach
> Encode URL
