### PR TITLE
Fix for Query Output Mapping 'OPTIONAL'

### DIFF
--- a/components/data-services/org.wso2.carbon.dataservices.core/src/main/java/org/wso2/carbon/dataservices/core/engine/StaticOutputElement.java
+++ b/components/data-services/org.wso2.carbon.dataservices.core/src/main/java/org/wso2/carbon/dataservices/core/engine/StaticOutputElement.java
@@ -245,8 +245,8 @@ public class StaticOutputElement extends OutputElement {
         } else {
             paramValue = this.getParamValue(params);
         }
-        /* if the result is null, this is an optional field then, do not write it out */
-        if (paramValue == null) {
+        /* if the result is null and this is an optional field, then do not write it out */
+        if (this.isOptional() && paramValue.getScalarValue() == null) {
         	return;
         }
         if (escapeNonPrintableChar && paramValue.getScalarValue() != null) {


### PR DESCRIPTION
Fixes enabling OPTIONAL for column elements when mapping output.
Now if a null value is retrieved for an OPTIONAL column, it is not
mapped to the response

Related issue : https://github.com/wso2/product-ei/issues/4670