### PR TITLE
Add support for 'optional' field of json output mapping of a Dataservice

### DIFF
--- a/components/data-services/org.wso2.carbon.dataservices.core/src/main/java/org/wso2/carbon/dataservices/core/description/query/QueryFactory.java
+++ b/components/data-services/org.wso2.carbon.dataservices.core/src/main/java/org/wso2/carbon/dataservices/core/description/query/QueryFactory.java
@@ -851,7 +851,7 @@ public class QueryFactory {
             } else if (DBSFields.TYPE.equals(name)) {
                 this.dataType = value;
             } else if (DBSFields.OPTIONAL.equals(name)) {
-            	this.isOptional = Boolean.parseBoolean(value);
+                this.isOptional = Boolean.parseBoolean(value);
             } else {
                 throw new DataServiceFault("Unrecognized option type '" + name + "', "
                         + "found: " + name);
@@ -870,9 +870,9 @@ public class QueryFactory {
             return dataType;
         }
 
-	    public boolean isOptional() {
-		    return isOptional;
-	    }
+	public boolean isOptional() {
+ 	    return isOptional;
+	}
     }
     
     private static ResultEntryColumnInfo extractJSONResultColumnInfo(
@@ -927,17 +927,17 @@ public class QueryFactory {
         } else if (item instanceof JSONArray) {
             throw new DataServiceFault("A JSON Array cannot be contained in the result records");
         } else {
-        	ResultEntryColumnInfo info = extractJSONResultColumnInfo(item.toString());
-        	childEl.addAttribute(DBSFields.COLUMN, info.getName(), null);
-        	if (info.getDataType() != null) {
-        		childEl.addAttribute(DBSFields.XSD_TYPE, info.getDataType(), null);
-        	}
-        	if (info.isOptional()) {
-        		childEl.addAttribute(DBSFields.OPTIONAL, String.valueOf(info.isOptional()), null);
-        	}
-        	if (info.getRequiredRoles() != null) {
-        		childEl.addAttribute(DBSFields.REQUIRED_ROLES, info.getRequiredRoles(), null);
-        	}
+            ResultEntryColumnInfo info = extractJSONResultColumnInfo(item.toString());
+            childEl.addAttribute(DBSFields.COLUMN, info.getName(), null);
+            if (info.getDataType() != null) {
+        	    childEl.addAttribute(DBSFields.XSD_TYPE, info.getDataType(), null);
+            }
+            if (info.isOptional()) {
+        	    childEl.addAttribute(DBSFields.OPTIONAL, String.valueOf(info.isOptional()), null);
+            }
+            if (info.getRequiredRoles() != null) {
+        	    childEl.addAttribute(DBSFields.REQUIRED_ROLES, info.getRequiredRoles(), null);
+            }
         }
     }
     

--- a/components/data-services/org.wso2.carbon.dataservices.core/src/main/java/org/wso2/carbon/dataservices/core/description/query/QueryFactory.java
+++ b/components/data-services/org.wso2.carbon.dataservices.core/src/main/java/org/wso2/carbon/dataservices/core/description/query/QueryFactory.java
@@ -930,13 +930,13 @@ public class QueryFactory {
             ResultEntryColumnInfo info = extractJSONResultColumnInfo(item.toString());
             childEl.addAttribute(DBSFields.COLUMN, info.getName(), null);
             if (info.getDataType() != null) {
-        	    childEl.addAttribute(DBSFields.XSD_TYPE, info.getDataType(), null);
+                childEl.addAttribute(DBSFields.XSD_TYPE, info.getDataType(), null);
             }
             if (info.isOptional()) {
-        	    childEl.addAttribute(DBSFields.OPTIONAL, String.valueOf(info.isOptional()), null);
+                childEl.addAttribute(DBSFields.OPTIONAL, String.valueOf(info.isOptional()), null);
             }
             if (info.getRequiredRoles() != null) {
-        	    childEl.addAttribute(DBSFields.REQUIRED_ROLES, info.getRequiredRoles(), null);
+                childEl.addAttribute(DBSFields.REQUIRED_ROLES, info.getRequiredRoles(), null);
             }
         }
     }

--- a/components/data-services/org.wso2.carbon.dataservices.core/src/main/java/org/wso2/carbon/dataservices/core/description/query/QueryFactory.java
+++ b/components/data-services/org.wso2.carbon.dataservices.core/src/main/java/org/wso2/carbon/dataservices/core/description/query/QueryFactory.java
@@ -810,6 +810,8 @@ public class QueryFactory {
         private String dataType;
         
         private String requiredRoles;
+
+        private boolean isOptional;
         
         public ResultEntryColumnInfo(String value) throws DataServiceFault {
             // {"name":"$jack(type:integer;requiredRoles:admin,role1)"
@@ -848,6 +850,8 @@ public class QueryFactory {
                 this.requiredRoles = value;
             } else if (DBSFields.TYPE.equals(name)) {
                 this.dataType = value;
+            } else if (DBSFields.OPTIONAL.equals(name)) {
+            	this.isOptional = Boolean.parseBoolean(value);
             } else {
                 throw new DataServiceFault("Unrecognized option type '" + name + "', "
                         + "found: " + name);
@@ -865,7 +869,10 @@ public class QueryFactory {
         public String getDataType() {
             return dataType;
         }
-        
+
+	    public boolean isOptional() {
+		    return isOptional;
+	    }
     }
     
     private static ResultEntryColumnInfo extractJSONResultColumnInfo(
@@ -920,14 +927,17 @@ public class QueryFactory {
         } else if (item instanceof JSONArray) {
             throw new DataServiceFault("A JSON Array cannot be contained in the result records");
         } else {
-            ResultEntryColumnInfo info = extractJSONResultColumnInfo(item.toString());
-            childEl.addAttribute(DBSFields.COLUMN, info.getName(), null);
-            if (info.getDataType() != null) {
-                childEl.addAttribute(DBSFields.XSD_TYPE, info.getDataType(), null);
-            }
-            if (info.getRequiredRoles() != null) {
-                childEl.addAttribute(DBSFields.REQUIRED_ROLES, info.getRequiredRoles(), null);
-            }
+        	ResultEntryColumnInfo info = extractJSONResultColumnInfo(item.toString());
+        	childEl.addAttribute(DBSFields.COLUMN, info.getName(), null);
+        	if (info.getDataType() != null) {
+        		childEl.addAttribute(DBSFields.XSD_TYPE, info.getDataType(), null);
+        	}
+        	if (info.isOptional()) {
+        		childEl.addAttribute(DBSFields.OPTIONAL, String.valueOf(info.isOptional()), null);
+        	}
+        	if (info.getRequiredRoles() != null) {
+        		childEl.addAttribute(DBSFields.REQUIRED_ROLES, info.getRequiredRoles(), null);
+        	}
         }
     }
     


### PR DESCRIPTION
## Purpose
> This PR will fix support for 'optional' field support for json output mapping of a Dataservice.
Fixes :  https://github.com/wso2/product-ei/issues/4707