### PR TITLE
Update ODataAdapter.java

### DIFF
--- a/components/data-services/org.wso2.carbon.dataservices.core/src/main/java/org/wso2/carbon/dataservices/core/odata/ODataAdapter.java
+++ b/components/data-services/org.wso2.carbon.dataservices.core/src/main/java/org/wso2/carbon/dataservices/core/odata/ODataAdapter.java
@@ -1858,7 +1858,7 @@ public class ODataAdapter implements ServiceHandler {
                 break;
             case INT16:
                 propertyType = EdmPrimitiveTypeKind.Int16.getFullQualifiedName().getFullQualifiedNameAsString();
-                value = paramValue == null ? null : ConverterUtil.convertToByte(paramValue);
+                value = paramValue == null ? null : ConverterUtil.convertToShort(paramValue);
                 break;
             case DOUBLE:
                 propertyType = EdmPrimitiveTypeKind.Double.getFullQualifiedName().getFullQualifiedNameAsString();


### PR DESCRIPTION
## Purpose
INT16 are being converted to Byte instead of Short. Since the max value of Byte is 127, this results in an out of range error.
Eg Columns in SQL Server database that are smallint causes 'Value out of range' error if they have any value that is greater that 127 and thus no OData is returned.

Here is a stack trace when I try to get OData from a table with a smallint column that contains year value (2019, 2020, etc)

ERROR {org.wso2.carbon.dataservices.core.odata.ODataAdapter} - Error occurred. :Value out of range. Value:"2020" Radix:10 java.lang.NumberFormatException: Value out of range. Value:"2020" Radix:10
	at java.base/java.lang.Byte.parseByte(Byte.java:154)
	at java.base/java.lang.Byte.parseByte(Byte.java:178)
	at org.apache.axis2.databinding.utils.ConverterUtil.convertToByte(ConverterUtil.java:853)
	at org.wso2.carbon.dataservices.core.odata.ODataAdapter.createPrimitive(ODataAdapter.java:1861)
	at org.wso2.carbon.dataservices.core.odata.ODataAdapter.createEntityCollectionFromDataEntryList(ODataAdapter.java:1121)
	at org.wso2.carbon.dataservices.core.odata.ODataAdapter.getEntityCollection(ODataAdapter.java:1359)
	at org.wso2.carbon.dataservices.core.odata.ODataAdapter.process(ODataAdapter.java:218)
	at org.wso2.carbon.dataservices.core.odata.ODataAdapter.read(ODataAdapter.java:398)
	at org.apache.olingo.server.core.requests.DataRequest$EntityRequest.execute(DataRequest.java:332)
	at org.apache.olingo.server.core.requests.DataRequest.execute(DataRequest.java:255)
	at org.apache.olingo.server.core.ServiceDispatcher.internalExecute(ServiceDispatcher.java:160)
	at org.apache.olingo.server.core.ServiceDispatcher.execute(ServiceDispatcher.java:98)
	at org.apache.olingo.server.core.OData4HttpHandler.process(OData4HttpHandler.java:67)
	at org.wso2.carbon.dataservices.core.odata.ODataServiceHandler.process(ODataServiceHandler.java:80)
	at org.wso2.carbon.dataservices.odata.endpoint.ODataEndpoint.process(ODataEndpoint.java:71)
	at org.wso2.carbon.dataservices.odata.ODataServlet.service(ODataServlet.java:31)
	at javax.servlet.http.HttpServlet.service(HttpServlet.java:741)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:231)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:166)
	at org.apache.tomcat.websocket.server.WsFilter.doFilter(WsFilter.java:53)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:193)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:166)
	at org.apache.catalina.core.StandardWrapperValve.invoke(StandardWrapperValve.java:202)
	at org.apache.catalina.core.StandardContextValve.invoke(StandardContextValve.java:96)
	at org.apache.catalina.authenticator.AuthenticatorBase.invoke(AuthenticatorBase.java:607)
	at org.apache.catalina.core.StandardHostValve.invoke(StandardHostValve.java:139)
	at org.apache.catalina.valves.ErrorReportValve.invoke(ErrorReportValve.java:92)
	at org.wso2.carbon.tomcat.ext.valves.CompositeValve.continueInvocation(CompositeValve.java:99)
	at org.wso2.carbon.tomcat.ext.valves.TomcatValveContainer.invokeValves(TomcatValveContainer.java:49)
	at org.wso2.carbon.tomcat.ext.valves.CompositeValve.invoke(CompositeValve.java:62)
	at org.wso2.carbon.tomcat.ext.valves.CarbonStuckThreadDetectionValve.invoke(CarbonStuckThreadDetectionValve.java:146)
	at org.apache.catalina.valves.AbstractAccessLogValve.invoke(AbstractAccessLogValve.java:678)
	at org.wso2.carbon.tomcat.ext.valves.CarbonContextCreatorValve.invoke(CarbonContextCreatorValve.java:57)
	at org.apache.catalina.core.StandardEngineValve.invoke(StandardEngineValve.java:74)
	at org.apache.catalina.connector.CoyoteAdapter.service(CoyoteAdapter.java:343)
	at org.apache.coyote.http11.Http11Processor.service(Http11Processor.java:408)
	at org.apache.coyote.AbstractProcessorLight.process(AbstractProcessorLight.java:66)
	at org.apache.coyote.AbstractProtocol$ConnectionHandler.process(AbstractProtocol.java:853)
	at org.apache.tomcat.util.net.NioEndpoint$SocketProcessor.doRun(NioEndpoint.java:1587)
	at org.apache.tomcat.util.net.SocketProcessorBase.run(SocketProcessorBase.java:49)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at org.apache.tomcat.util.threads.TaskThread$WrappingRunnable.run(TaskThread.java:61)
	at java.base/java.lang.Thread.run(Thread.java:834)

## Goals
INT16 (and thus smallint in SQL Server) are converted to Short instead of Byte

