### PR TITLE
Fix EI-5133: Introduce a property to hide current params in the DSFault msg

### DIFF
--- a/components/data-services/org.wso2.carbon.dataservices.common/src/main/java/org/wso2/carbon/dataservices/common/DBConstants.java
+++ b/components/data-services/org.wso2.carbon.dataservices.common/src/main/java/org/wso2/carbon/dataservices/common/DBConstants.java
@@ -84,7 +84,8 @@ public final class DBConstants {
     public static final String SQL_DRIVER_CLASS_NAME = "org.wso2.carbon.dataservices.sql.driver.TDriver";
     public static final String SECURITY_MODULE_NAME = "rampart";
     public static final String TENANT_IN_ONLY_MESSAGE = "TENANT_IN_ONLY_MESSAGE";
-        
+    public static final String DISABLE_CURRENT_PARAMS_IN_LOG = "dss.disable.current.params";
+
     /**
      * Codes to be used as fault codes.
      */

--- a/components/data-services/org.wso2.carbon.dataservices.core/src/main/java/org/wso2/carbon/dataservices/core/DataServiceDocLitWrappedSchemaGenerator.java
+++ b/components/data-services/org.wso2.carbon.dataservices.core/src/main/java/org/wso2/carbon/dataservices/core/DataServiceDocLitWrappedSchemaGenerator.java
@@ -597,9 +597,15 @@ public class DataServiceDocLitWrappedSchemaGenerator {
         XmlSchemaComplexType type = createComplexType(cparams, DBConstants.WSO2_DS_NAMESPACE,
                 DBConstants.DS_FAULT_ELEMENT, false);
         element.setType(type);
-        createAndAddSimpleStringElements(cparams, element,
-                DBConstants.FaultParams.CURRENT_PARAMS, DBConstants.FaultParams.CURRENT_REQUEST_NAME,
-                DBConstants.FaultParams.NESTED_EXCEPTION);
+		String isCurrentParamsDisabled = System.getProperty(DBConstants.DISABLE_CURRENT_PARAMS_IN_LOG);
+		if ("true".equalsIgnoreCase(isCurrentParamsDisabled)) {
+			createAndAddSimpleStringElements(cparams, element,
+					DBConstants.FaultParams.CURRENT_REQUEST_NAME, DBConstants.FaultParams.NESTED_EXCEPTION);
+		} else {
+			createAndAddSimpleStringElements(cparams, element,
+					DBConstants.FaultParams.CURRENT_PARAMS, DBConstants.FaultParams.CURRENT_REQUEST_NAME,
+					DBConstants.FaultParams.NESTED_EXCEPTION);
+		}
         XmlSchemaElement dataServiceElement = createElement(cparams, DBConstants.WSO2_DS_NAMESPACE,
                 DBConstants.FaultParams.SOURCE_DATA_SERVICE, false);
         XmlSchemaComplexType dataServiceComplexType = createComplexType(cparams, DBConstants.WSO2_DS_NAMESPACE,

--- a/components/data-services/org.wso2.carbon.dataservices.core/src/main/java/org/wso2/carbon/dataservices/core/DataServiceFault.java
+++ b/components/data-services/org.wso2.carbon.dataservices.core/src/main/java/org/wso2/carbon/dataservices/core/DataServiceFault.java
@@ -198,7 +198,8 @@ public class DataServiceFault extends Exception {
 			buff.append("Current Request Name: " + this.getCurrentRequestName() + "\n");
             getPropertyMap().put(DBConstants.FaultParams.CURRENT_REQUEST_NAME, this.getCurrentRequestName());
 		}
-		if (this.getCurrentParams() != null) {
+		String isCurrentParamsDisabled = System.getProperty(DBConstants.DISABLE_CURRENT_PARAMS_IN_LOG);
+		if (this.getCurrentParams() != null && !("true".equalsIgnoreCase(isCurrentParamsDisabled))) {
 			buff.append("Current Params: " + this.getCurrentParams() + "\n");
             getPropertyMap().put(DBConstants.FaultParams.CURRENT_PARAMS, this.getCurrentParams().toString());
 		}


### PR DESCRIPTION
## Purpose
This is to fix wso2/product-ei#5133

If the current params should be hidden in the log file and then in the wsdl, the following system property should be enabled.
dss.disable.current.params=true